### PR TITLE
don't use file path as part of s3 key

### DIFF
--- a/mhook.go
+++ b/mhook.go
@@ -130,7 +130,7 @@ func (m *Mhook) Upload(source string, prefix string) error {
 		reader := io.TeeReader(file, bar)
 		uploadInput := &s3manager.UploadInput{
 			Bucket: aws.String(m.Bucket),
-			Key:    m.Key(prefix + path),
+			Key:    m.Key(prefix + filepath.Base(path)),
 			Body:   reader,
 		}
 		fmt.Println(*uploadInput.Key)


### PR DESCRIPTION
If I'm uploading /var/tmp/foobar, let's not have /var/tmp in the key path. If
we want to specify the upload path, we can use the prefix argument, eg
mhook upload <...> /var/tmp/foobar /var/tmp/