### PR TITLE
Add wait command.

### DIFF
--- a/glide.yaml
+++ b/glide.yaml
@@ -3,12 +3,13 @@ package: main
 import:
   - package: github.com/codegangsta/cli
   - package: github.com/aws/aws-sdk-go
-    ref: v0.10.2
+    version: 64ecfaae861c2f24bb2e8cf47c257a40e2b4f0d4
     vcs: git
-  # this is dependency of aws-sdk-go, but glide doesn't install it unless you
-  #   # explicitly define it :-/
-  - package: github.com/vaughan0/go-ini
-  - package: github.com/andrew-d/go-termutil
   - package: github.com/cheggaaa/pb
     ref: 0947789f943d6187227e4c53061dafc5d762efef
     vcs: git
+  # these are dependencies of aws-sdk-go, but glide doesn't install it unless you
+  #   # explicitly define it :-/ we can remove when we move to glide ^0.8
+  - package: github.com/go-ini/ini
+  - package: github.com/andrew-d/go-termutil
+  - package: github.com/jmespath/go-jmespath


### PR DESCRIPTION
also adds --wait flag for download command

This will cause mhook to wait until a key becomes available until continuing.

It uses the aws-sdk wait method which uses a preconfigured timeout (20 retires, 5 second waits iirc). We can change this if it becomes needful

pegs to commit of go-aws-sdk. We should update this to a tag asap