### PR TITLE
Allow downloading of a single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,32 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof
+
+mhook
+/vendor/**
+!/vendor/vendor.json
+/.wercker
+
+.DS_Store
+*.swp


### PR DESCRIPTION
This bypasses the need for the ListObjects permission on the S3 bucket.